### PR TITLE
fix: wrapped `removeChild` call in clearRuler in conditional 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,9 @@ class ScaleText extends Component {
   }
 
   clearRuler() {
-    document.body.removeChild(this.ruler);
+    if (this.ruler) {
+      document.body.removeChild(this.ruler);
+    }
     this.ruler = null;
   }
 


### PR DESCRIPTION
- because of async nature of resize events, ruler element might have been cleared in the previous request, so this ensures we don't get `NotFoundError` thrown if ruler DOM element was already removed.