### PR TITLE
Fixing invalid PropTypes boolean for widthOnly

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -154,7 +154,7 @@ ScaleText.propTypes = {
   children: PropTypes.node.isRequired,
   minFontSize: PropTypes.number.isRequired,
   maxFontSize: PropTypes.number.isRequired,
-  widthOnly: PropTypes.boolean
+  widthOnly: PropTypes.bool
 };
 
 ScaleText.defaultProps = {


### PR DESCRIPTION
And fixing this issue https://github.com/datchley/react-scale-text/issues/15